### PR TITLE
Remove highlight on buttons

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    <link rel="stylesheet" type="text/css" href="style.css">
     <div class="mdl-grid">
         <div class="mdl-cell mdl-cell--2-col mdl-cell--1-col-tablet mdl-cell--hide-phone"></div>
         <div class="mdl-cell mdl-cell--8-col mdl-cell--6-col-tablet mdl-cell--4-col-phone">

--- a/site/layouts/style.css
+++ b/site/layouts/style.css
@@ -1,0 +1,7 @@
+mdl-icon-toggle {
+    -webkit-user-select: none; /* Chrome/Safari */        
+    -moz-user-select: none; /* Firefox */
+    -ms-user-select: none; /* IE10+ */
+    -o-user-select: none; /* Not implemented yet */
+    user-select: none; /* Not implemented yet */
+}


### PR DESCRIPTION
Currently, when you click a button (specifically, the tutor availability button), double-clicking will highlight the element, and looks really bad.

This should fix it.